### PR TITLE
Update Emscripten to v4.18

### DIFF
--- a/.github/workflows/build-validate-emscripten.yaml
+++ b/.github/workflows/build-validate-emscripten.yaml
@@ -23,4 +23,4 @@ jobs:
       host-platform: 'windows-latest'
       target-platform: 'web'
       targets: "${{ matrix.project }}-${{ matrix.pipeline }}-${{ matrix.config }}"
-      clang-version: '21'
+      clang-version: '22'

--- a/source/code/modules/webgpu_renderer/private/webgpu_commands.cxx
+++ b/source/code/modules/webgpu_renderer/private/webgpu_commands.cxx
@@ -80,8 +80,8 @@ namespace ice::render::webgpu
         //     attachment_count += 1;
         // }
 
-        WGPURenderPassDescriptor descriptor{};
-        descriptor.label = "Default Renderpass";
+        WGPURenderPassDescriptor descriptor = WGPU_RENDER_PASS_DESCRIPTOR_INIT;
+        descriptor.label = wgpu_string("Default Renderpass");
         descriptor.colorAttachmentCount = attachment_count;
         descriptor.colorAttachments = attachments;
         descriptor.depthStencilAttachment = nullptr;
@@ -140,8 +140,8 @@ namespace ice::render::webgpu
 
         ICE_ASSERT_CORE(subpass.depth_stencil_attachment.layout != ImageLayout::DepthStencil);
 
-        WGPURenderPassDescriptor descriptor{};
-        descriptor.label = "Default Renderpass";
+        WGPURenderPassDescriptor descriptor = WGPU_RENDER_PASS_DESCRIPTOR_INIT;
+        descriptor.label = wgpu_string("Default Renderpass");
         descriptor.colorAttachmentCount = attachment_count;
         descriptor.colorAttachments = attachments;
         descriptor.depthStencilAttachment = nullptr;
@@ -296,8 +296,8 @@ namespace ice::render::webgpu
 
         //wgpuCommandEncoderInsertDebugMarker(webgpu_cmds->command_encoder, "End");
 
-        WGPUCommandBufferDescriptor descriptor{};
-        descriptor.label = "Command Buffer";
+        WGPUCommandBufferDescriptor descriptor = WGPU_COMMAND_BUFFER_DESCRIPTOR_INIT;
+        descriptor.label = wgpu_string("Command Buffer");
         webgpu_cmds->command_buffer = wgpuCommandEncoderFinish(webgpu_cmds->command_encoder, &descriptor);
     }
 
@@ -321,14 +321,13 @@ namespace ice::render::webgpu
             bytes_per_row
         );
 
-        WGPUImageCopyBuffer source{};
+        WGPUTexelCopyBufferInfo source = WGPU_TEXEL_COPY_BUFFER_INFO_INIT;
         source.buffer = WebGPUBuffer::native(image_contents)->wgpu_buffer;
-
         source.layout.offset = 0;
         source.layout.bytesPerRow = bytes_per_row;
         source.layout.rowsPerImage = extents.y;
 
-        WGPUImageCopyTexture destination{};
+        WGPUTexelCopyTextureInfo destination = WGPU_TEXEL_COPY_TEXTURE_INFO_INIT;
         destination.aspect = WGPUTextureAspect_Undefined;
         destination.mipLevel = 0;
         destination.origin = { 0, 0, 0 };

--- a/source/code/modules/webgpu_renderer/private/webgpu_queue.cxx
+++ b/source/code/modules/webgpu_renderer/private/webgpu_queue.cxx
@@ -49,7 +49,7 @@ namespace ice::render::webgpu
             webgpu_cmds->type = type;
 
             WGPUCommandEncoderDescriptor descriptor{};
-            descriptor.label = type == CommandBufferType::Primary ? "Primary Command Encoded" : "Secondary Command Encoder";
+            descriptor.label = wgpu_string(type == CommandBufferType::Primary ? "Primary Command Encoded" : "Secondary Command Encoder");
             webgpu_cmds->command_encoder = wgpuDeviceCreateCommandEncoder(_wgpu_device, &descriptor);
 
             out_buffer = WebGPUCommandBuffer::handle(webgpu_cmds);
@@ -73,7 +73,7 @@ namespace ice::render::webgpu
             wgpuCommandEncoderRelease(webgpu_cmds->command_encoder);
 
             WGPUCommandEncoderDescriptor descriptor{};
-            descriptor.label = type == CommandBufferType::Primary ? "Primary Command Encoded" : "Secondary Command Encoder";
+            descriptor.label = wgpu_string(type == CommandBufferType::Primary ? "Primary Command Encoded" : "Secondary Command Encoder");
             webgpu_cmds->command_encoder = wgpuDeviceCreateCommandEncoder(_wgpu_device, &descriptor);
 
             auto it = ice::multi_hashmap::find_first(_wgpu_command_buffers, pool_index);
@@ -120,11 +120,11 @@ namespace ice::render::webgpu
                 WGPUCommandEncoderDescriptor descriptor{};
                 if (it.value()->type == CommandBufferType::Secondary)
                 {
-                    descriptor.label = "Primary Command Encoded";
+                    descriptor.label = wgpu_string("Primary Command Encoded");
                 }
                 else
                 {
-                    descriptor.label = "Secondary Command Encoded";
+                    descriptor.label = wgpu_string("Secondary Command Encoded");
                 }
                 it.value()->command_encoder = wgpuDeviceCreateCommandEncoder(_wgpu_device, &descriptor);
 

--- a/source/code/modules/webgpu_renderer/private/webgpu_resources.hxx
+++ b/source/code/modules/webgpu_renderer/private/webgpu_resources.hxx
@@ -36,19 +36,19 @@ namespace ice::render::webgpu
         }
     };
 
-    inline auto native_shader_stages(ice::render::ShaderStageFlags flags) noexcept -> WGPUShaderStageFlags
+    inline auto native_shader_stages(ice::render::ShaderStageFlags flags) noexcept -> WGPUShaderStage
     {
         bool const unsupported_flags = ice::has_any(flags, ~(ShaderStageFlags::FragmentStage | ShaderStageFlags::VertexStage));
         ICE_ASSERT(unsupported_flags == false, "WebGPU rendered only supports vertex, fragment and compute stages.");
 
-        WGPUShaderStageFlags result = WGPUShaderStage_None;
+        WGPUShaderStage result = WGPUShaderStage_None;
         if (ice::has_all(flags, ShaderStageFlags::VertexStage))
         {
-            result = WGPUShaderStageFlags(result | WGPUShaderStage_Vertex);
+            result = WGPUShaderStage(result | WGPUShaderStage_Vertex);
         }
         if (ice::has_all(flags, ShaderStageFlags::FragmentStage))
         {
-            result = WGPUShaderStageFlags(result | WGPUShaderStage_Fragment);
+            result = WGPUShaderStage(result | WGPUShaderStage_Fragment);
         }
         return result;
     }

--- a/source/code/modules/webgpu_renderer/private/webgpu_shader.hxx
+++ b/source/code/modules/webgpu_renderer/private/webgpu_shader.hxx
@@ -48,7 +48,7 @@ namespace ice::render::webgpu
         case ShaderAttribType::Vec3f: return WGPUVertexFormat_Float32x3;
         case ShaderAttribType::Vec4f: return WGPUVertexFormat_Float32x4;
         case ShaderAttribType::Vec4f_Unorm8: return WGPUVertexFormat_Unorm8x4;
-        default: return WGPUVertexFormat_Undefined;
+        default: return WGPUVertexFormat_Force32;
         }
     }
 

--- a/source/code/modules/webgpu_renderer/private/webgpu_surface.hxx
+++ b/source/code/modules/webgpu_renderer/private/webgpu_surface.hxx
@@ -15,10 +15,12 @@ namespace ice::render::webgpu
         WebGPURenderSurface(
             WGPUSurface wgpu_surface,
             WGPUTextureFormat wgpu_surface_format,
+            WGPUPresentMode wgpu_present_mode,
             ice::render::SurfaceInfo surface_info
         ) noexcept
             : _wgpu_surface{ wgpu_surface }
             , _wgpu_surface_format{ wgpu_surface_format }
+            , _wgpu_present_mode{ wgpu_present_mode }
             , _surface_info{ surface_info }
         {
         }
@@ -30,6 +32,7 @@ namespace ice::render::webgpu
 
         WGPUSurface const _wgpu_surface;
         WGPUTextureFormat _wgpu_surface_format;
+        WGPUPresentMode _wgpu_present_mode;
         ice::render::SurfaceInfo const _surface_info;
     };
 

--- a/source/code/modules/webgpu_renderer/private/webgpu_swapchain.cxx
+++ b/source/code/modules/webgpu_renderer/private/webgpu_swapchain.cxx
@@ -8,24 +8,36 @@ namespace ice::render::webgpu
 {
 
     WebGPUSwapchain::WebGPUSwapchain(
-        WGPUSwapChain wgpu_swapchain,
+        WGPUSurface wgpu_surface,
         WGPUTextureFormat wgpu_format,
         ice::vec2u extent
     ) noexcept
-        : _wgpu_swapchain{ wgpu_swapchain }
+        : _wgpu_surface{ wgpu_surface }
         , _wgpu_format{ wgpu_format }
         , _extent{ extent }
         , _images{ { }, { } }
         , _current_index{ 1 }
     {
+        wgpuSurfaceGetCurrentTexture(_wgpu_surface, &_texture);
+        ICE_ASSERT_CORE(_texture.status == WGPUSurfaceGetCurrentTextureStatus_SuccessOptimal
+            || _texture.status == WGPUSurfaceGetCurrentTextureStatus_SuccessSuboptimal);
         // We aquire the first image so we don't need to handle a special case in 'aquire_image'
-        _images[_current_index].wgpu_texture_view = wgpuSwapChainGetCurrentTextureView(_wgpu_swapchain);
+        _images[_current_index].wgpu_texture = _texture.texture;
+
+        WGPUTextureViewDescriptor view_descriptor = WGPU_TEXTURE_VIEW_DESCRIPTOR_INIT;
+        view_descriptor.arrayLayerCount = 1;
+        view_descriptor.baseArrayLayer = 0;
+        view_descriptor.mipLevelCount = 1;
+        view_descriptor.baseMipLevel = 0;
+        view_descriptor.format = _wgpu_format;
+        view_descriptor.aspect = WGPUTextureAspect_All;
+        view_descriptor.usage = WGPUTextureUsage_RenderAttachment;
+        _images[_current_index].wgpu_texture_view = wgpuTextureCreateView(_texture.texture, &view_descriptor);
     }
 
     WebGPUSwapchain::~WebGPUSwapchain() noexcept
     {
-        wgpuTextureRelease(_images[_current_index].wgpu_texture);
-        wgpuSwapChainRelease(_wgpu_swapchain);
+        wgpuSurfaceUnconfigure(_wgpu_surface);
     }
 
     auto WebGPUSwapchain::extent() const noexcept -> ice::vec2u
@@ -51,10 +63,27 @@ namespace ice::render::webgpu
     auto WebGPUSwapchain::aquire_image() noexcept -> ice::u32
     {
         // We release the previous textures since it's no longer needed
+        wgpuTextureRelease(_images[_current_index].wgpu_texture);
         wgpuTextureViewRelease(_images[_current_index].wgpu_texture_view);
+
         _current_index = (_current_index + 1) % image_count();
         // And allocate the new texture for the current frame
-        _images[_current_index].wgpu_texture_view = wgpuSwapChainGetCurrentTextureView(_wgpu_swapchain);
+        wgpuSurfaceGetCurrentTexture(_wgpu_surface, &_texture);
+        ICE_ASSERT_CORE(_texture.status == WGPUSurfaceGetCurrentTextureStatus_SuccessOptimal
+            || _texture.status == WGPUSurfaceGetCurrentTextureStatus_SuccessSuboptimal);
+        // We aquire the first image so we don't need to handle a special case in 'aquire_image'
+        _images[_current_index].wgpu_texture = _texture.texture;
+
+        WGPUTextureViewDescriptor view_descriptor = WGPU_TEXTURE_VIEW_DESCRIPTOR_INIT;
+        view_descriptor.arrayLayerCount = 1;
+        view_descriptor.baseArrayLayer = 0;
+        view_descriptor.mipLevelCount = 1;
+        view_descriptor.baseMipLevel = 0;
+        view_descriptor.format = _wgpu_format;
+        view_descriptor.aspect = WGPUTextureAspect_All;
+        view_descriptor.usage = WGPUTextureUsage_RenderAttachment;
+        _images[_current_index].wgpu_texture_view = wgpuTextureCreateView(_texture.texture, &view_descriptor);
+
         return _current_index;
     }
 

--- a/source/code/modules/webgpu_renderer/private/webgpu_swapchain.hxx
+++ b/source/code/modules/webgpu_renderer/private/webgpu_swapchain.hxx
@@ -13,7 +13,7 @@ namespace ice::render::webgpu
     {
     public:
         WebGPUSwapchain(
-            WGPUSwapChain wgpu_swapchain,
+            WGPUSurface wgpu_surface,
             WGPUTextureFormat wgpu_format,
             ice::vec2u extent
         ) noexcept;
@@ -31,10 +31,11 @@ namespace ice::render::webgpu
 
         auto current_image_index() const noexcept -> ice::u32 override;
 
-        WGPUSwapChain const _wgpu_swapchain;
+        WGPUSurface const _wgpu_surface;
     private:
         WGPUTextureFormat const _wgpu_format;
         ice::vec2u const _extent;
+        WGPUSurfaceTexture _texture;
         WebGPUImage _images[2];
         uint32_t _current_index;
     };

--- a/source/code/modules/webgpu_renderer/private/webgpu_utils.hxx
+++ b/source/code/modules/webgpu_renderer/private/webgpu_utils.hxx
@@ -13,6 +13,11 @@ namespace ice::render::webgpu
 
     constexpr ice::LogTagDefinition LogTag_WebGPU = ice::create_log_tag(ice::LogTag::Module, "WebGPU");
 
+    constexpr auto wgpu_string(ice::String value) noexcept -> WGPUStringView
+    {
+        return WGPUStringView{ .data = value._data, .length = value._size };
+    }
+
 #define ICE_LOG_WGPU(severity, message, ...) \
     ICE_LOG(severity, ice::render::webgpu::LogTag_WebGPU, message, __VA_ARGS__)
 

--- a/source/code/modules/webgpu_renderer/webgpu_renderer.bff
+++ b/source/code/modules/webgpu_renderer/webgpu_renderer.bff
@@ -17,12 +17,5 @@
             'render_system'
         }
     ]
-
-    .Public =
-    [
-        .Libs = {
-            'webgpu'
-        }
-    ]
 ]
 .Projects + .Project

--- a/source/configs.bff
+++ b/source/configs.bff
@@ -216,6 +216,8 @@
         // Requires options for multithreading
         '-pthread'
         '-sSHARED_MEMORY=1'
+        // WebGPU (Dawn)
+        '--use-port=emdawnwebgpu'
     }
     .LinkLinkerOptions = {
         '-pthread'
@@ -228,9 +230,10 @@
         // '-sINITIAL_MEMORY=1073741824' // 1GiB
         '-sMALLOC=mimalloc'
         '-sABORTING_MALLOC=1'
-        '-sUSE_WEBGPU=1'
         '-sUSE_GLFW=3'
         '-sEXIT_RUNTIME'
+        // WebGPU (Dawn)
+        '--use-port=emdawnwebgpu'
     }
 ]
 
@@ -282,6 +285,24 @@
         // "-gseparate-dwarf=temp.debug.wasm"
         // TODO: Decide where memory growth might be necessary
         // "-sALLOW_MEMORY_GROWTH"
+    }
+]
+
+.Config_Profile_WebAsm =
+[
+    .Name = 'Config-Profile-WebAsm'
+    .Requires = { 'Profile', 'SDK-WebAsm', .Kind_WindowedApp }
+    .LinkLinkerOptions = {
+        // '--closure=1' (Fix access to Node from Emscpripted)
+    }
+]
+
+.Config_Release_WebAsm =
+[
+    .Name = 'Config-Release-WebAsm'
+    .Requires = { 'Release', 'SDK-WebAsm', .Kind_WindowedApp }
+    .LinkLinkerOptions = {
+        // '--closure=1' (Fix access to Node from Emscpripted)
     }
 ]
 
@@ -380,7 +401,9 @@
     .Config_Develop_MSVC
     .Config_Profile
     .Config_Profile_MSVC
+    .Config_Profile_WebAsm
     .Config_Release
     .Config_Release_MSVC
+    .Config_Release_WebAsm
     .Config_Vulkan
 }

--- a/source/fbuild.bff
+++ b/source/fbuild.bff
@@ -103,7 +103,7 @@ Settings
     Using( .Piepline_WebAsm )
 
     // Might need to be updated whenever latest EmScripten is downloaded
-    .EMSDKVersion = '4.0.9'
+    .EMSDKVersion = '4.0.18'
 
     .PipelineName = 'WebAsm'
     .PipelineAllowUnityBuilds = true
@@ -111,7 +111,7 @@ Settings
     .PipelineTags = { 'Monolythic' }
 
     .PipelineConanProfile = 'WebAsm'
-    .PipelineToolchain = 'em4-clang-21.0.0'
+    .PipelineToolchain = 'em4-clang-22.0.0'
 
     // Disable explicitly (we dont want VS configs for WebAssembly for now)
     .PipelineVSInfo =

--- a/tools/settings.json
+++ b/tools/settings.json
@@ -35,7 +35,7 @@
     "webasm": {
         "emscripten": {
             "location": "build/webasm",
-            "version": "4.0.9"
+            "version": "4.0.18"
         }
     },
     "doxy": {


### PR DESCRIPTION
With the recent releases, Emscripten dropped their own WebGPU implementation in favor of Dawns (Googles) implementation. With this, the render module did require quite some changes, but mostly just renaming types.

Outside of WebGPU nothing else required additional attention.